### PR TITLE
Feature/ is_last_message

### DIFF
--- a/ai_config/ai_prompts.py
+++ b/ai_config/ai_prompts.py
@@ -298,8 +298,6 @@ Follow the verification steps to link your e-wallet.
 If you encounter any issues during setup, our support team is ready to assist you."
 """
 
-
-
 ADMIN_CONVERSATION_PROMPT = """You are a friendly gaming platform assistant
 for a gambling company in Malaysia.
         you are to be focused on natural conversation and
@@ -328,7 +326,6 @@ You can also mention that there are alot of transactions happening at the same t
 - when given a yes/no question, the answer has to be exactly what is in the database.
 for exmaple "do you have a max withdrawal limit?"
  the answer has to be "No, we do not have a max withdrawal limit."
-
 
 RESPONSE PATTERNS:
 - For thank you: Use variations like "You're welcome!", "Happy to help!", "Anytime!"

--- a/ai_config/ai_prompts.py
+++ b/ai_config/ai_prompts.py
@@ -298,6 +298,8 @@ Follow the verification steps to link your e-wallet.
 If you encounter any issues during setup, our support team is ready to assist you."
 """
 
+
+
 ADMIN_CONVERSATION_PROMPT = """You are a friendly gaming platform assistant
 for a gambling company in Malaysia.
         you are to be focused on natural conversation and
@@ -366,3 +368,7 @@ PROHIBITED:
 - Time-specific greetings
 - Saying "please note"
 - Suggesting customer service unless necessary"""
+
+IS_LAST_MESSAGE_PROMPT = """This is the last message in the conversation.
+Please provide a conclusive response without asking any more questions
+and thank the user for their message."""

--- a/api/chatbot.py
+++ b/api/chatbot.py
@@ -1280,7 +1280,7 @@ def prompt_conversation_admin(
             print(f"Is last message flag: {is_last_message}")
             if is_last_message:
                 system_prompt = """This is the last message in the conversation.
-                Please provide a conclusive response without asking any more questions 
+                Please provide a conclusive response without asking any more questions
                 and thank the user for their message."""
             else:
                 system_prompt = ADMIN_CONVERSATION_PROMPT

--- a/api/chatbot.py
+++ b/api/chatbot.py
@@ -1280,7 +1280,8 @@ def prompt_conversation_admin(
             print(f"Is last message flag: {is_last_message}")
             if is_last_message:
                 system_prompt = """This is the last message in the conversation.
-                Please provide a conclusive response without asking any more questions and thank the user for their message."""
+                Please provide a conclusive response without asking any more questions 
+                and thank the user for their message."""
             else:
                 system_prompt = ADMIN_CONVERSATION_PROMPT
 

--- a/api/chatbot.py
+++ b/api/chatbot.py
@@ -54,6 +54,7 @@ from ai_config.ai_prompts import (
     TRANSLATION_EN_TO_CN_PROMPT,
     RAG_PROMPT_TEMPLATE,
     ADMIN_CONVERSATION_PROMPT,
+    IS_LAST_MESSAGE_PROMPT,
 )
 
 
@@ -1208,7 +1209,7 @@ def prompt_conversation_admin(
     admin_id,
     bot_id,
     user_id,
-    language_code="en",
+    language_code=LANGUAGE_DEFAULT,
     is_last_message=False,
 ):
     start_time = time.time()
@@ -1279,9 +1280,7 @@ def prompt_conversation_admin(
             # Debug print for last_message flag
             print(f"Is last message flag: {is_last_message}")
             if is_last_message:
-                system_prompt = """This is the last message in the conversation.
-                Please provide a conclusive response without asking any more questions
-                and thank the user for their message."""
+                system_prompt = ADMIN_CONVERSATION_PROMPT + IS_LAST_MESSAGE_PROMPT
             else:
                 system_prompt = ADMIN_CONVERSATION_PROMPT
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -137,12 +137,12 @@ class PromptConversationAdminSerializer(serializers.Serializer):
     user_id = serializers.CharField(required=True)
     admin_id = serializers.CharField(required=False, default="")
     bot_id = serializers.CharField(required=False, default="")
+    is_last_message = serializers.BooleanField(required=False, default=False)
     language = serializers.CharField(
         max_length=10,
         required=False,
         default="en",
     )
-    
 
     def validate_language(self, value):
         """Validate the language code is supported"""

--- a/api/views/conversation_view.py
+++ b/api/views/conversation_view.py
@@ -585,6 +585,7 @@ class PromptConversationAdminView(MongoDBMixin, APIView):
                 bot_id=validated_data.get("bot_id", ""),
                 user_id=validated_data["user_id"],
                 language_code=language_code,
+                is_last_message=validated_data.get("is_last_message", False),
             )
 
             generation_time = time.time() - generation_start


### PR DESCRIPTION
feature add -  is_last_message flag for prompt_conversation_admin

Description:
added a flag (Default) False, for the is_last_message, it is asked for in request, and returned in response, when changed to "True", their is an addtional prompt added to let the AI respond in way to end the conversation handling better.

Changes Made:
added is_last_message to serilaizers (Default=False)
added is_last_message to views\
added is_last_message to the function prompt_conversation_admin, logic is just if the request contains a "true" it added a sentence for the prompt to let the AI respond in a better way, 
There is a debug print statement to show if the is_last_message prompt being used



Testing
new API via postman
tested conversations with false for multiple Q/A pairs, then tested with True, to see the outcome, tested without adding in the field "is_last_message", to make sure the response contains the right fields.
I have run black .
i have run flake8 . --exclude venv

Additional Notes
We can add more and more logic to the AI repsonse for the last message, that kind of fine tuning I will build over the coming days.
